### PR TITLE
Sc 8588 use blockchain api to fetch transactions testnet

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdk 31
     defaultConfig {
         applicationId "io.horizontalsystems.bitcoinkit.demo"
         minSdkVersion 23

--- a/app/src/main/java/io/horizontalsystems/bitcoinkit/demo/MainViewModel.kt
+++ b/app/src/main/java/io/horizontalsystems/bitcoinkit/demo/MainViewModel.kt
@@ -44,10 +44,11 @@ class MainViewModel : ViewModel(), BitcoinKit.Listener {
 
     private lateinit var bitcoinKit: BitcoinKit
 
-    private val walletId = "FastSyncWallet13"
-    private val networkType = BitcoinKit.NetworkType.MainNet
+
+    private val walletId = "SyncDemoWallet1"
+    private val networkType = BitcoinKit.NetworkType.TestNet
     private val syncMode = BitcoinCore.SyncMode.Api()
-    private val bip = Bip.BIP44
+    private val bip = Bip.BIP84
 
     fun init() {
         //TODO create unique seed phrase,perhaps using shared preferences?
@@ -66,9 +67,10 @@ class MainViewModel : ViewModel(), BitcoinKit.Listener {
                 386526600, 187228578,
                 "00000000000000000005cff1d36f64f1ceef5d8a0da26ebbd671f1d1a9a1cff6".toReversedByteArray()), 750792)
 
+        val authKey = ""
 
-        bitcoinKit = BitcoinKit(App.instance, words, passphrase, walletId, networkType, syncMode = syncMode, bip = bip, block = mainnetBlock)
 
+        bitcoinKit = BitcoinKit(App.instance, words, passphrase, walletId, networkType, syncMode = syncMode, bip = bip, block = testNetBlock, authKey = authKey)
         bitcoinKit.listener = this
 
         networkName = bitcoinKit.networkName

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
@@ -163,7 +163,7 @@ class BitcoinCoreBuilder {
 
         val connectionManager = ConnectionManager(context)
 
-        val hdWallet = HDWallet(seed, network.coinType, purpose = bip.purpose)
+        val hdWallet = HDWallet(seed, network.coinType, purpose = bip.purpose, gapLimit = 5)
 
         val wallet = Wallet(hdWallet)
         val publicKeyManager = PublicKeyManager.create(storage, wallet, restoreKeyConverterChain)

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/BitcoinCore.kt
@@ -163,7 +163,11 @@ class BitcoinCoreBuilder {
 
         val connectionManager = ConnectionManager(context)
 
-        val hdWallet = HDWallet(seed, network.coinType, purpose = bip.purpose, gapLimit = 5)
+        var gapLimit = 20
+        if (network.coinType == 1) {
+            gapLimit = 5
+        }
+        val hdWallet = HDWallet(seed, network.coinType, purpose = bip.purpose, gapLimit = gapLimit)
 
         val wallet = Wallet(hdWallet)
         val publicKeyManager = PublicKeyManager.create(storage, wallet, restoreKeyConverterChain)

--- a/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/BlockchainApi.kt
+++ b/bitcoincore/src/main/kotlin/io/horizontalsystems/bitcoincore/managers/BlockchainApi.kt
@@ -1,0 +1,57 @@
+package io.horizontalsystems.bitcoincore.managers
+
+import com.eclipsesource.json.Json
+import com.eclipsesource.json.JsonObject
+import io.horizontalsystems.bitcoincore.core.IInitialSyncApi
+import java.util.logging.Logger
+
+class BlockchainApi(host: String, authKey: String) : IInitialSyncApi {
+    private val apiManager = ApiManager(host)
+    private val jwtApiManager = ApiManager(host)
+    private val authKey = authKey
+    private val logger = Logger.getLogger("BlockchainApi")
+
+    override fun getTransactions(addresses: List<String>): List<TransactionItem> {
+
+        val jwtResponse = jwtApiManager.get("/authentication/requestJWT", authKey).asObject()
+
+        val jwt = jwtResponse.get("data").asObject().get("token").asString()
+
+        val requestData = JsonObject().apply {
+            this["addresses"] = Json.array(*addresses.toTypedArray())
+        }
+
+        logger.info("Request transactions for ${addresses.size} addresses: [${addresses.first()}, ...]")
+
+        val response = apiManager.post("bitcoin/testnet/getTransactions", requestData.toString(), jwt).asArray()
+
+        logger.info("Got ${response.size()} transactions for requested addresses")
+
+        val transactions = mutableListOf<TransactionItem>()
+
+        for (txItem in response) {
+            val tx = txItem.asObject()
+
+            val blockHashJson = tx["block"] ?: continue
+            val blockHash = if (blockHashJson.isString) blockHashJson.asString() else continue
+
+            val outputs = mutableListOf<TransactionOutputItem>()
+            for (outputItem in tx["outputs"].asArray()) {
+                val outputJson = outputItem.asObject()
+
+                val scriptJson = outputJson["script"] ?: continue
+                val addressJson = outputJson["address"] ?: continue
+
+                if (scriptJson.isString && addressJson.isString) {
+                    outputs.add(TransactionOutputItem(scriptJson.asString(), addressJson.asString()))
+                }
+            }
+
+            transactions.add(TransactionItem(blockHash, tx["height"].asInt(), outputs))
+        }
+
+        return transactions
+    }
+
+
+}

--- a/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/BitcoinKit.kt
+++ b/bitcoinkit/src/main/kotlin/io/horizontalsystems/bitcoinkit/BitcoinKit.kt
@@ -74,9 +74,11 @@ class BitcoinKit : AbstractKit {
             syncMode: SyncMode = SyncMode.Api(),
             confirmationsThreshold: Int = 6,
             bip: Bip = Bip.BIP44,
-            block: Block? = null
+            block: Block? = null,
+            authKey: String
 
-    ) : this(context, Mnemonic().toSeed(words, passphrase), walletId, networkType, peerSize, syncMode, confirmationsThreshold, bip, block = block)
+
+    ) : this(context, Mnemonic().toSeed(words, passphrase), walletId, networkType, peerSize, syncMode, confirmationsThreshold, bip, block = block, authKey = authKey)
 
 
 
@@ -101,7 +103,8 @@ class BitcoinKit : AbstractKit {
             syncMode: SyncMode = SyncMode.Api(),
             confirmationsThreshold: Int = 6,
             bip: Bip = Bip.BIP44,
-            block: Block?
+            block: Block?,
+            authKey: String
     ) {
         val database = CoreDatabase.getInstance(context, getDatabaseName(networkType, walletId, syncMode, bip))
         val storage = Storage(database)
@@ -113,7 +116,7 @@ class BitcoinKit : AbstractKit {
                 MainNet(Checkpoint("", block))
             }
             NetworkType.TestNet -> {
-                initialSyncApi = BCoinApi("https://btc-testnet.horizontalsystems.xyz/api")
+                initialSyncApi = BlockchainApi("https://dev-api.moneyclip.io/blockchainapi", authKey)
                 TestNet(Checkpoint("", block))
             }
             NetworkType.RegTest -> {

--- a/tools/src/main/java/io/horizontalsystems/tools/BuildCheckpoints.kt
+++ b/tools/src/main/java/io/horizontalsystems/tools/BuildCheckpoints.kt
@@ -5,6 +5,7 @@ import io.horizontalsystems.bitcoincash.TestNetBitcoinCash
 import io.horizontalsystems.bitcoincore.extensions.toHexString
 import io.horizontalsystems.bitcoincore.io.BitcoinOutput
 import io.horizontalsystems.bitcoincore.models.Block
+import io.horizontalsystems.bitcoincore.models.Checkpoint
 import io.horizontalsystems.bitcoincore.network.Network
 import io.horizontalsystems.bitcoinkit.MainNet
 import io.horizontalsystems.bitcoinkit.TestNet
@@ -21,8 +22,8 @@ class BuildCheckpoints : CheckpointSyncer.Listener {
 
     private val syncers = mutableListOf<CheckpointSyncer>().also {
         // Bitcoin
-        it.add(CheckpointSyncer(MainNet(), 2016, 1, this))
-        it.add(CheckpointSyncer(TestNet(), 2016, 1, this))
+        it.add(CheckpointSyncer(MainNet(Checkpoint("")), 2016, 1, this))
+        it.add(CheckpointSyncer(TestNet(Checkpoint("")), 2016, 1, this))
 
         // Bitcoin Cash
         it.add(CheckpointSyncer(MainNetBitcoinCash(), 147, 147, this))


### PR DESCRIPTION
Changes Made:
- New parameter (AUTHKEY) which is used to get the JWT from the blockchain API. 
- Making a new copy of `BCoinApi` and naming it `BlockchainApi`. 
- Adding functionality to support JWTs for Blockchain API Auth.
- Adding a `gapLimit` conditional which limits how many addresses we query for when we are running in `TestNet` or `RegTest` mode. This helps us avoid rate limits, and should not have an impact on testing.